### PR TITLE
Ran go imports on termios

### DIFF
--- a/termios/termios.go
+++ b/termios/termios.go
@@ -9,9 +9,9 @@ import (
 )
 
 const (
-        TCIFLUSH  = 0
-        TCOFLUSH  = 1
-        TCIOFLUSH = 2
+	TCIFLUSH  = 0
+	TCOFLUSH  = 1
+	TCIOFLUSH = 2
 
 	TCSANOW   = 0
 	TCSADRAIN = 1

--- a/termios/termios_bsd.go
+++ b/termios/termios_bsd.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	FREAD     = 0x0001
-	FWRITE    = 0x0002
+	FREAD  = 0x0001
+	FWRITE = 0x0002
 )
 
 // Tcgetattr gets the current serial port settings.


### PR DESCRIPTION
This PR fixes a bit of whitespace with `go imports`.
