### PR TITLE
Expose Ptsname as API

### DIFF
--- a/termios/pty.go
+++ b/termios/pty.go
@@ -22,7 +22,7 @@ func Pty() (*os.File, *os.File, error) {
 		return nil, nil, err
 	}
 
-	sname, err := ptsname(ptm)
+	sname, err := Ptsname(ptm)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/termios/pty_darwin.go
+++ b/termios/pty_darwin.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-func ptsname(fd uintptr) (string, error) {
+func Ptsname(fd uintptr) (string, error) {
 	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
 
 	err := ioctl(fd, syscall.TIOCPTYGNAME, uintptr(unsafe.Pointer(&n[0])))

--- a/termios/pty_linux.go
+++ b/termios/pty_linux.go
@@ -6,7 +6,7 @@ import (
 	"unsafe"
 )
 
-func ptsname(fd uintptr) (string, error) {
+func Ptsname(fd uintptr) (string, error) {
 	var n uintptr
 	err := ioctl(fd, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
 	if err != nil {


### PR DESCRIPTION
In Go's coding convention we usually return the value of a function
directly along with the error .
Ptsname is useful for some applications, expose it as an API.