### PR TITLE
Fix TIOCFLUSH ioctl on bsd and darwin.

### DIFF
--- a/termios/termios_bsd.go
+++ b/termios/termios_bsd.go
@@ -69,7 +69,7 @@ func Tcflush(fd, which uintptr) error {
 	default:
 		return syscall.EINVAL
 	}
-	return ioctl(fd, syscall.TCIOFLUSH, uintptr(unsafe.Pointer(&com)))
+	return ioctl(fd, syscall.TIOCFLUSH, uintptr(unsafe.Pointer(&com)))
 }
 
 // Cfgetispeed returns the input baud rate stored in the termios structure.

--- a/termios/termios_bsd_test.go
+++ b/termios/termios_bsd_test.go
@@ -12,7 +12,6 @@ func TestTcflush(t *testing.T) {
 	defer f.Close()
 
 	if err := Tcflush(f.Fd(), syscall.TCIOFLUSH); err != nil {
-		checktty(t, err)
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This pull request fixes a typo in termios/termios_bsd.go that was causing `termios.Tcflush()` to fail on darwin.  Instead of passing `syscall.TIOCFLUSH to ioctl()` it was passing `syscall.TCIOFLUSH`.  It also updates the `TestTcflush()` test, which now works on darwin, so that the test no longer ignores the error.

-stuart
