### PR TITLE
Fix FreeBSD support

### DIFF
--- a/term_darwin.go
+++ b/term_darwin.go
@@ -1,5 +1,3 @@
-// +build freebsd openbsd netbsd
-
 package term
 
 import "syscall"
@@ -7,7 +5,7 @@ import "syscall"
 type attr syscall.Termios
 
 func (a *attr) setSpeed(baud int) error {
-	var rate uint32
+	var rate uint64
 	switch baud {
 	case 50:
 		rate = syscall.B50

--- a/termios/pty.go
+++ b/termios/pty.go
@@ -6,18 +6,18 @@ import (
 	"syscall"
 )
 
+func open_device(path string) (uintptr, error) {
+	fd, err := syscall.Open(path, syscall.O_NOCTTY|syscall.O_RDWR|syscall.O_CLOEXEC, 0666)
+	if err != nil {
+		return 0, fmt.Errorf("unable to open %q: %v", path, err)
+	}
+	return uintptr(fd), nil
+}
+
 // Pty returns a UNIX 98 pseudoterminal device.
 // Pty returns a pair of fds representing the master and slave pair.
 func Pty() (*os.File, *os.File, error) {
-	open := func(path string) (uintptr, error) {
-		fd, err := syscall.Open(path, syscall.O_NOCTTY|syscall.O_RDWR|syscall.O_CLOEXEC, 0666)
-		if err != nil {
-			return 0, fmt.Errorf("unable to open %q: %v", path, err)
-		}
-		return uintptr(fd), nil
-	}
-
-	ptm, err := open("/dev/ptmx")
+	ptm, err := open_pty_master()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -37,7 +37,7 @@ func Pty() (*os.File, *os.File, error) {
 		return nil, nil, err
 	}
 
-	pts, err := open(sname)
+	pts, err := open_device(sname)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/termios/pty_bsd.go
+++ b/termios/pty_bsd.go
@@ -1,0 +1,27 @@
+// +build freebsd openbsd netbsd
+
+package termios
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+func Ptsname(fd uintptr) (string, error) {
+	var n uintptr
+	err := ioctl(fd, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("/dev/pts/%d", n), nil
+}
+
+func grantpt(fd uintptr) error {
+	var n uintptr
+	return ioctl(fd, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
+}
+
+func unlockpt(fd uintptr) error {
+	return nil
+}

--- a/termios/pty_bsd.go
+++ b/termios/pty_bsd.go
@@ -8,6 +8,20 @@ import (
 	"unsafe"
 )
 
+func posix_openpt(oflag int) (fd uintptr, err error) {
+	// Copied from debian-golang-pty/pty_freebsd.go.
+	r0, _, e1 := syscall.Syscall(syscall.SYS_POSIX_OPENPT, uintptr(oflag), 0, 0)
+	fd = uintptr(r0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+func open_pty_master() (uintptr, error) {
+	return posix_openpt(syscall.O_NOCTTY|syscall.O_RDWR|syscall.O_CLOEXEC)
+}
+
 func Ptsname(fd uintptr) (string, error) {
 	var n uintptr
 	err := ioctl(fd, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))

--- a/termios/pty_darwin.go
+++ b/termios/pty_darwin.go
@@ -6,6 +6,10 @@ import (
 	"unsafe"
 )
 
+func open_pty_master() (uintptr, error) {
+	return open_device("/dev/ptmx")
+}
+
 func Ptsname(fd uintptr) (string, error) {
 	n := make([]byte, _IOC_PARM_LEN(syscall.TIOCPTYGNAME))
 

--- a/termios/pty_linux.go
+++ b/termios/pty_linux.go
@@ -6,6 +6,10 @@ import (
 	"unsafe"
 )
 
+func open_pty_master() (uintptr, error) {
+	return open_device("/dev/ptmx")
+}
+
 func Ptsname(fd uintptr) (string, error) {
 	var n uintptr
 	err := ioctl(fd, syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))

--- a/termios/termios_bsd.go
+++ b/termios/termios_bsd.go
@@ -73,10 +73,10 @@ func Tcflush(fd, which uintptr) error {
 }
 
 // Cfgetispeed returns the input baud rate stored in the termios structure.
-func Cfgetispeed(attr *syscall.Termios) uint64 { return attr.Ispeed }
+func Cfgetispeed(attr *syscall.Termios) uint32 { return uint32(attr.Ispeed) }
 
 // Cfgetospeed returns the output baud rate stored in the termios structure.
-func Cfgetospeed(attr *syscall.Termios) uint64 { return attr.Ospeed }
+func Cfgetospeed(attr *syscall.Termios) uint32 { return uint32(attr.Ospeed) }
 
 // Tiocinq returns the number of bytes in the input buffer.
 func Tiocinq(fd uintptr, argp *int) error {


### PR DESCRIPTION
The following two commits were necessary to make this module build on FreeBSD 11-CURRENT. It was tested successfully from Concourse's fly CLI (see https://github.com/concourse/fly).

I admit I didn't test on other BSD flavors. I know nothing about the Go langage so your comments on this patch are welcome!