### PR TITLE
Add support for Solaris

### DIFF
--- a/term_open_posix.go
+++ b/term_open_posix.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/pkg/term/termios"
-	"fmt"
 	"golang.org/x/sys/unix"
 )
 

--- a/term_open_posix.go
+++ b/term_open_posix.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/pkg/term/termios"
-	"golang.org/x/sys/unix"
 )
 
 // Open opens an asynchronous communications port.

--- a/term_open_posix.go
+++ b/term_open_posix.go
@@ -1,0 +1,38 @@
+// +build !windows,!solaris
+
+package term
+
+import (
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/pkg/term/termios"
+	"fmt"
+	"golang.org/x/sys/unix"
+)
+
+// Open opens an asynchronous communications port.
+func Open(name string, options ...func(*Term) error) (*Term, error) {
+	fd, e := syscall.Open(name, syscall.O_NOCTTY|syscall.O_CLOEXEC|syscall.O_NDELAY|syscall.O_RDWR, 0666)
+	if e != nil {
+		return nil, &os.PathError{"open", name, e}
+	}
+
+	t := Term{name: name, fd: fd}
+	if err := termios.Tcgetattr(uintptr(t.fd), &t.orig); err != nil {
+		time.Sleep(time.Second * 100)
+		return nil, err
+	}
+	if err := t.SetOption(options...); err != nil {
+		return nil, err
+	}
+	return &t, syscall.SetNonblock(t.fd, false)
+}
+
+// Restore restores the state of the terminal captured at the point that
+// the terminal was originally opened.
+func (t *Term) Restore() error {
+	return termios.Tcsetattr(uintptr(t.fd), termios.TCIOFLUSH, &t.orig)
+}
+

--- a/term_posix.go
+++ b/term_posix.go
@@ -3,7 +3,6 @@
 package term
 
 import (
-	"os"
 	"syscall"
 	"time"
 
@@ -15,22 +14,6 @@ type Term struct {
 	name string
 	fd   int
 	orig syscall.Termios // original state of the terminal, see Open and Restore
-}
-
-// Open opens an asynchronous communications port.
-func Open(name string, options ...func(*Term) error) (*Term, error) {
-	fd, e := syscall.Open(name, syscall.O_NOCTTY|syscall.O_CLOEXEC|syscall.O_NDELAY|syscall.O_RDWR, 0666)
-	if e != nil {
-		return nil, &os.PathError{"open", name, e}
-	}
-	t := Term{name: name, fd: fd}
-	if err := termios.Tcgetattr(uintptr(t.fd), &t.orig); err != nil {
-		return nil, err
-	}
-	if err := t.SetOption(options...); err != nil {
-		return nil, err
-	}
-	return &t, syscall.SetNonblock(t.fd, false)
 }
 
 // SetCbreak sets cbreak mode.
@@ -204,12 +187,6 @@ func (t *Term) RTS() (bool, error) {
 	var status int
 	err := termios.Tiocmget(uintptr(t.fd), &status)
 	return status&syscall.TIOCM_RTS == syscall.TIOCM_RTS, err
-}
-
-// Restore restores the state of the terminal captured at the point that
-// the terminal was originally opened.
-func (t *Term) Restore() error {
-	return termios.Tcsetattr(uintptr(t.fd), termios.TCIOFLUSH, &t.orig)
 }
 
 // Close closes the device and releases any associated resources.

--- a/term_solaris.go
+++ b/term_solaris.go
@@ -72,16 +72,12 @@ func Open(name string, options ...func(*Term) error) (*Term, error) {
 		return nil, &os.PathError{"open", name, e}
 	}
 
-	ptem := "ptem"
-	err := unix.IoctlSetInt(fd, C.I_PUSH, int(uintptr(unsafe.Pointer(syscall.StringBytePtr(ptem)))))
-	if err != nil {
-		return nil, err
-	}
-
-	ldterm := "ldterm"
-	err = unix.IoctlSetInt(fd, C.I_PUSH, int(uintptr(unsafe.Pointer(syscall.StringBytePtr(ldterm)))))
-	if err != nil {
-		return nil, err
+	modules := [2]string{"ptem", "ldterm"}
+	for _, mod := range modules {
+		err := unix.IoctlSetInt(fd, C.I_PUSH, int(uintptr(unsafe.Pointer(syscall.StringBytePtr(mod)))))
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	t := Term{name: name, fd: fd}

--- a/term_solaris.go
+++ b/term_solaris.go
@@ -1,0 +1,104 @@
+package term
+
+// #include<stropts.h>
+import "C"
+
+import (
+	"syscall"
+	"github.com/pkg/term/termios"
+	"os"
+	"golang.org/x/sys/unix"
+	"unsafe"
+)
+
+type attr syscall.Termios
+
+func (a *attr) setSpeed(baud int) error {
+	var rate uint32
+	switch baud {
+	case 50:
+		rate = syscall.B50
+	case 75:
+		rate = syscall.B75
+	case 110:
+		rate = syscall.B110
+	case 134:
+		rate = syscall.B134
+	case 150:
+		rate = syscall.B150
+	case 200:
+		rate = syscall.B200
+	case 300:
+		rate = syscall.B300
+	case 600:
+		rate = syscall.B600
+	case 1200:
+		rate = syscall.B1200
+	case 1800:
+		rate = syscall.B1800
+	case 2400:
+		rate = syscall.B2400
+	case 4800:
+		rate = syscall.B4800
+	case 9600:
+		rate = syscall.B9600
+	case 19200:
+		rate = syscall.B19200
+	case 38400:
+		rate = syscall.B38400
+	case 57600:
+		rate = syscall.B57600
+	case 115200:
+		rate = syscall.B115200
+	case 230400:
+		rate = syscall.B230400
+	case 460800:
+		rate = syscall.B460800
+	case 921600:
+		rate = syscall.B921600
+	default:
+		return syscall.EINVAL
+	}
+	(*syscall.Termios)(a).Cflag = syscall.CS8 | syscall.CREAD | syscall.CLOCAL | rate
+	//(*syscall.Termios)(a).Ispeed = rate
+	//(*syscall.Termios)(a).Ospeed = rate
+	return nil
+}
+
+// Open opens an asynchronous communications port.
+func Open(name string, options ...func(*Term) error) (*Term, error) {
+	fd, e := syscall.Open(name, syscall.O_NOCTTY|syscall.O_CLOEXEC|syscall.O_NDELAY|syscall.O_RDWR, 0666)
+	if e != nil {
+		return nil, &os.PathError{"open", name, e}
+	}
+
+	ptem := "ptem"
+	err := unix.IoctlSetInt(fd, C.I_PUSH, int(uintptr(unsafe.Pointer(syscall.StringBytePtr(ptem)))))
+	if err != nil {
+		return nil, err
+	}
+
+	ldterm := "ldterm"
+	err = unix.IoctlSetInt(fd, C.I_PUSH, int(uintptr(unsafe.Pointer(syscall.StringBytePtr(ldterm)))))
+	if err != nil {
+		return nil, err
+	}
+
+	t := Term{name: name, fd: fd}
+	termios.Tcgetattr(uintptr(t.fd), &t.orig)
+	if err := termios.Tcgetattr(uintptr(t.fd), &t.orig); err != nil {
+		return nil, err
+	}
+
+	if err := t.SetOption(options...); err != nil {
+		return nil, err
+	}
+
+	return &t, syscall.SetNonblock(t.fd, false)
+}
+
+// Restore restores the state of the terminal captured at the point that
+// the terminal was originally opened.
+func (t *Term) Restore() error {
+	return termios.Tcsetattr(uintptr(t.fd), termios.TCSANOW, &t.orig)
+}

--- a/term_solaris.go
+++ b/term_solaris.go
@@ -59,9 +59,17 @@ func (a *attr) setSpeed(baud int) error {
 	default:
 		return syscall.EINVAL
 	}
-	(*syscall.Termios)(a).Cflag = syscall.CS8 | syscall.CREAD | syscall.CLOCAL | rate
-	//(*syscall.Termios)(a).Ispeed = rate
-	//(*syscall.Termios)(a).Ospeed = rate
+
+	err := termios.Cfsetispeed((*syscall.Termios)(a), uintptr(rate))
+	if err != nil {
+		return err
+	}
+
+	err = termios.Cfsetospeed((*syscall.Termios)(a), uintptr(rate))
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/term_test.go
+++ b/term_test.go
@@ -2,9 +2,9 @@ package term
 
 import (
 	"testing"
-	"time"
 
 	"github.com/pkg/term/termios"
+	"time"
 )
 
 // assert that Term implements the same method set across

--- a/termios/ioctl.go
+++ b/termios/ioctl.go
@@ -1,4 +1,4 @@
-// +build !windows
+// +build !windows,!solaris
 
 package termios
 

--- a/termios/ioctl_solaris.go
+++ b/termios/ioctl_solaris.go
@@ -1,0 +1,7 @@
+package termios
+
+import "golang.org/x/sys/unix"
+
+func ioctl(fd, request, argp uintptr) error {
+	return unix.IoctlSetInt(int(fd), int(request), int(argp))
+}

--- a/termios/pty_solaris.go
+++ b/termios/pty_solaris.go
@@ -1,0 +1,33 @@
+package termios
+
+// #include<stdlib.h>
+import "C"
+
+import "syscall"
+
+func open_pty_master() (uintptr, error) {
+	return open_device("/dev/ptmx")
+}
+
+func Ptsname(fd uintptr) (string, error) {
+	slavename := C.GoString(C.ptsname(C.int(fd)))
+	return slavename, nil
+}
+
+func grantpt(fd uintptr) error {
+	rc := C.grantpt(C.int(fd))
+	if rc == 0 {
+		return nil
+	} else {
+		return syscall.Errno(rc)
+	}
+}
+
+func unlockpt(fd uintptr) error {
+	rc := C.unlockpt(C.int(fd))
+	if rc == 0 {
+		return nil
+	} else {
+		return syscall.Errno(rc)
+	}
+}

--- a/termios/termios.go
+++ b/termios/termios.go
@@ -7,16 +7,6 @@ import (
 	"unsafe"
 )
 
-const (
-	TCIFLUSH  = 0
-	TCOFLUSH  = 1
-	TCIOFLUSH = 2
-
-	TCSANOW   = 0
-	TCSADRAIN = 1
-	TCSAFLUSH = 2
-)
-
 // Tiocmget returns the state of the MODEM bits.
 func Tiocmget(fd uintptr, status *int) error {
 	return ioctl(fd, syscall.TIOCMGET, uintptr(unsafe.Pointer(status)))

--- a/termios/termios_const.go
+++ b/termios/termios_const.go
@@ -1,0 +1,13 @@
+// +build !windows,!solaris
+
+package termios
+
+const (
+	TCIFLUSH  = 0
+	TCOFLUSH  = 1
+	TCIOFLUSH = 2
+
+	TCSANOW   = 0
+	TCSADRAIN = 1
+	TCSAFLUSH = 2
+)

--- a/termios/termios_const_solaris.go
+++ b/termios/termios_const_solaris.go
@@ -1,0 +1,14 @@
+package termios
+
+// #include<termios.h>
+import "C"
+
+const (
+	TCIFLUSH  = C.TCIFLUSH
+	TCOFLUSH  = C.TCOFLUSH
+	TCIOFLUSH = C.TCIOFLUSH
+
+	TCSANOW   = C.TCSANOW
+	TCSADRAIN = C.TCSADRAIN
+	TCSAFLUSH = C.TCSAFLUSH
+)

--- a/termios/termios_solaris.go
+++ b/termios/termios_solaris.go
@@ -1,0 +1,88 @@
+package termios
+
+// #include <termios.h>
+// typedef struct termios termios_t;
+import "C"
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+	"unsafe"
+)
+
+const (
+	TCSETS  = 0x5402
+	TCSETSW = 0x5403
+	TCSETSF = 0x5404
+	TCFLSH  = 0x540B
+	TCSBRK  = 0x5409
+	TCSBRKP = 0x5425
+
+	IXON    = 0x00000400
+	IXANY   = 0x00000800
+	IXOFF   = 0x00001000
+	CRTSCTS = 0x80000000
+)
+
+// See /usr/include/sys/termios.h
+const FIORDCHK = C.FIORDCHK
+
+// Tcgetattr gets the current serial port settings.
+func Tcgetattr(fd uintptr, argp *syscall.Termios) error {
+	termios, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
+	*argp = syscall.Termios(*termios)
+	return err
+}
+
+// Tcsetattr sets the current serial port settings.
+func Tcsetattr(fd, action uintptr, argp *syscall.Termios) error {
+	return unix.IoctlSetTermios(int(fd), int(action), (*unix.Termios)(argp))
+}
+
+// Tcsendbreak transmits a continuous stream of zero-valued bits for a specific
+// duration, if the terminal is using asynchronous serial data transmission. If
+// duration is zero, it transmits zero-valued bits for at least 0.25 seconds, and not more that 0.5 seconds.
+// If duration is not zero, it sends zero-valued bits for some
+// implementation-defined length of time.
+func Tcsendbreak(fd, duration uintptr) error {
+	return ioctl(fd, TCSBRKP, duration)
+}
+
+// Tcdrain waits until all output written to the object referred to by fd has been transmitted.
+func Tcdrain(fd uintptr) error {
+	// simulate drain with TCSADRAIN
+	var attr syscall.Termios
+	if err := Tcgetattr(fd, &attr); err != nil {
+		return err
+	}
+	return Tcsetattr(fd, TCSADRAIN, &attr)
+}
+
+// Tcflush discards data written to the object referred to by fd but not transmitted, or data received but not read, depending on the value of selector.
+func Tcflush(fd, selector uintptr) error {
+	return ioctl(fd, TCFLSH, selector)
+}
+
+// Tiocinq returns the number of bytes in the input buffer.
+func Tiocinq(fd uintptr, argp *int) (err error) {
+	*argp, err = unix.IoctlGetInt(int(fd), FIORDCHK)
+	return err
+}
+
+// Tiocoutq return the number of bytes in the output buffer.
+func Tiocoutq(fd uintptr, argp *int) error {
+	return ioctl(fd, syscall.TIOCOUTQ, uintptr(unsafe.Pointer(argp)))
+}
+
+// Cfgetispeed returns the input baud rate stored in the termios structure.
+func Cfgetispeed(attr *syscall.Termios) uint32 {
+	solTermios := (*unix.Termios)(attr)
+	return uint32(C.cfgetispeed((*C.termios_t)(unsafe.Pointer(&solTermios))))
+}
+
+// Cfgetospeed returns the output baud rate stored in the termios structure.
+func Cfgetospeed(attr *syscall.Termios) uint32 {
+	solTermios := (*unix.Termios)(attr)
+	return uint32(C.cfgetospeed((*C.termios_t)(unsafe.Pointer(&solTermios))))
+}

--- a/termios/termios_solaris.go
+++ b/termios/termios_solaris.go
@@ -78,11 +78,25 @@ func Tiocoutq(fd uintptr, argp *int) error {
 // Cfgetispeed returns the input baud rate stored in the termios structure.
 func Cfgetispeed(attr *syscall.Termios) uint32 {
 	solTermios := (*unix.Termios)(attr)
-	return uint32(C.cfgetispeed((*C.termios_t)(unsafe.Pointer(&solTermios))))
+	return uint32(C.cfgetispeed((*C.termios_t)(unsafe.Pointer(solTermios))))
+}
+
+// Cfsetispeed sets the input baud rate stored in the termios structure.
+func Cfsetispeed(attr *syscall.Termios, speed uintptr) error {
+	solTermios := (*unix.Termios)(attr)
+	_, err := C.cfsetispeed((*C.termios_t)(unsafe.Pointer(solTermios)), C.speed_t(speed))
+	return err
 }
 
 // Cfgetospeed returns the output baud rate stored in the termios structure.
 func Cfgetospeed(attr *syscall.Termios) uint32 {
 	solTermios := (*unix.Termios)(attr)
-	return uint32(C.cfgetospeed((*C.termios_t)(unsafe.Pointer(&solTermios))))
+	return uint32(C.cfgetospeed((*C.termios_t)(unsafe.Pointer(solTermios))))
+}
+
+// Cfsetospeed sets the output baud rate stored in the termios structure.
+func Cfsetospeed(attr *syscall.Termios, speed uintptr) error {
+	solTermios := (*unix.Termios)(attr)
+	_, err := C.cfsetospeed((*C.termios_t)(unsafe.Pointer(solTermios)), C.speed_t(speed))
+	return err
 }


### PR DESCRIPTION
Hi. Please consider this pull request for adding Solaris support to this package.

Some points to note are:
- Solaris requires the `ptem` (Pseudo-TTY Emulation) and `ldterm` (Line Discipline) stream modules to be pushed when using ptys. So I had to separate out the `term.Open()` call for that.
- Some pty ioctls are replace by explicit system calls - notably `ptsname`, `grantpt` and `unlockpt`.