### PR TITLE
Add new method Fd() for getting the underlying file descriptor

### DIFF
--- a/term_posix.go
+++ b/term_posix.go
@@ -16,6 +16,11 @@ type Term struct {
 	orig syscall.Termios // original state of the terminal, see Open and Restore
 }
 
+// Get the underlying file descriptor for use in combination with other system APIs.
+func (t *Term) Fd() int {
+	return t.fd
+}
+
 // SetCbreak sets cbreak mode.
 func (t *Term) SetCbreak() error {
 	return t.SetOption(CBreakMode)


### PR DESCRIPTION
This can be used in combination with e.g. epoll(7)
