### PR TITLE
Compile on DragonFly BSD, NetBSD, and OpenBSD

### DIFF
--- a/term_bsdi.go
+++ b/term_bsdi.go
@@ -1,0 +1,55 @@
+// +build netbsd openbsd
+
+package term
+
+import "syscall"
+
+type attr syscall.Termios
+
+func (a *attr) setSpeed(baud int) error {
+	var rate int32
+	switch baud {
+	case 50:
+		rate = syscall.B50
+	case 75:
+		rate = syscall.B75
+	case 110:
+		rate = syscall.B110
+	case 134:
+		rate = syscall.B134
+	case 150:
+		rate = syscall.B150
+	case 200:
+		rate = syscall.B200
+	case 300:
+		rate = syscall.B300
+	case 600:
+		rate = syscall.B600
+	case 1200:
+		rate = syscall.B1200
+	case 1800:
+		rate = syscall.B1800
+	case 2400:
+		rate = syscall.B2400
+	case 4800:
+		rate = syscall.B4800
+	case 9600:
+		rate = syscall.B9600
+	case 19200:
+		rate = syscall.B19200
+	case 38400:
+		rate = syscall.B38400
+	case 57600:
+		rate = syscall.B57600
+	case 115200:
+		rate = syscall.B115200
+	case 230400:
+		rate = syscall.B230400
+	default:
+		return syscall.EINVAL
+	}
+	(*syscall.Termios)(a).Cflag = syscall.CS8 | syscall.CREAD | syscall.CLOCAL | uint32(rate)
+	(*syscall.Termios)(a).Ispeed = rate
+	(*syscall.Termios)(a).Ospeed = rate
+	return nil
+}

--- a/term_bsdu.go
+++ b/term_bsdu.go
@@ -1,4 +1,4 @@
-// +build freebsd openbsd netbsd
+// +build dragonfly freebsd
 
 package term
 

--- a/termios/pty_bsd.go
+++ b/termios/pty_bsd.go
@@ -1,0 +1,37 @@
+// +build dragonfly netbsd openbsd
+
+package termios
+
+// #include<stdlib.h>
+import "C"
+
+import "syscall"
+
+func open_pty_master() (uintptr, error) {
+	rc := C.posix_openpt(syscall.O_NOCTTY | syscall.O_RDWR)
+	if rc < 0 {
+		return 0, syscall.Errno(rc)
+	}
+	return uintptr(rc), nil
+}
+
+func Ptsname(fd uintptr) (string, error) {
+	slavename := C.GoString(C.ptsname(C.int(fd)))
+	return slavename, nil
+}
+
+func grantpt(fd uintptr) error {
+	rc := C.grantpt(C.int(fd))
+	if rc == 0 {
+		return nil
+	}
+	return syscall.Errno(rc)
+}
+
+func unlockpt(fd uintptr) error {
+	rc := C.unlockpt(C.int(fd))
+	if rc == 0 {
+		return nil
+	}
+	return syscall.Errno(rc)
+}

--- a/termios/pty_freebsd.go
+++ b/termios/pty_freebsd.go
@@ -1,5 +1,3 @@
-// +build freebsd openbsd netbsd
-
 package termios
 
 import (


### PR DESCRIPTION
This fixes issue #25 for me on OpenBSD.  This should work on DragonFly BSD and NetBSD too, based on their man pages, but I don't have access to those machines for testing myself.