### PR TITLE
Add methods to read modem control lines

### DIFF
--- a/term_posix.go
+++ b/term_posix.go
@@ -155,6 +155,13 @@ func (t *Term) SendBreak() error {
 	return termios.Tcsendbreak(uintptr(t.fd), 0)
 }
 
+// DCD returns the state of the DCD (data carrier detect) signal.
+func (t *Term) DCD() (bool, error) {
+	var status int
+	err := termios.Tiocmget(uintptr(t.fd), &status)
+	return status&syscall.TIOCM_CD == syscall.TIOCM_CD, err
+}
+
 // SetDTR sets the DTR (data terminal ready) signal.
 func (t *Term) SetDTR(v bool) error {
 	bits := syscall.TIOCM_DTR
@@ -172,6 +179,13 @@ func (t *Term) DTR() (bool, error) {
 	return status&syscall.TIOCM_DTR == syscall.TIOCM_DTR, err
 }
 
+// DSR returns the state of the DSR (data set ready) signal.
+func (t *Term) DSR() (bool, error) {
+	var status int
+	err := termios.Tiocmget(uintptr(t.fd), &status)
+	return status&syscall.TIOCM_DSR == syscall.TIOCM_DSR, err
+}
+
 // SetRTS sets the RTS (data terminal ready) signal.
 func (t *Term) SetRTS(v bool) error {
 	bits := syscall.TIOCM_RTS
@@ -182,11 +196,25 @@ func (t *Term) SetRTS(v bool) error {
 	}
 }
 
-// RTS returns the state of the RTS (data terminal ready) signal.
+// RTS returns the state of the RTS (request to send) signal.
 func (t *Term) RTS() (bool, error) {
 	var status int
 	err := termios.Tiocmget(uintptr(t.fd), &status)
 	return status&syscall.TIOCM_RTS == syscall.TIOCM_RTS, err
+}
+
+// CTS returns the state of the CTS (clear to send) signal.
+func (t *Term) CTS() (bool, error) {
+	var status int
+	err := termios.Tiocmget(uintptr(t.fd), &status)
+	return status&syscall.TIOCM_CTS == syscall.TIOCM_CTS, err
+}
+
+// RI returns the state of the RI (ring indicator) signal.
+func (t *Term) RI() (bool, error) {
+	var status int
+	err := termios.Tiocmget(uintptr(t.fd), &status)
+	return status&syscall.TIOCM_RI == syscall.TIOCM_RI, err
 }
 
 // Close closes the device and releases any associated resources.

--- a/term_test.go
+++ b/term_test.go
@@ -12,9 +12,13 @@ import (
 var _ interface {
 	Available() (int, error)
 	Buffered() (int, error)
+	CTS() (bool, error)
 	Close() error
+	DCD() (bool, error)
+	DSR() (bool, error)
 	DTR() (bool, error)
 	Flush() error
+	RI() (bool, error)
 	RTS() (bool, error)
 	Read(b []byte) (int, error)
 	Restore() error


### PR DESCRIPTION
This adds support to read DCD, DSR, CTS, and RI, which are all input pins on a DTE (computer) serial port.