### PR TITLE
termios: reimplement for NetBSD without cgo

### DIFF
--- a/termios/pty_bsd.go
+++ b/termios/pty_bsd.go
@@ -1,4 +1,4 @@
-// +build dragonfly netbsd openbsd
+// +build dragonfly openbsd
 
 package termios
 

--- a/termios/pty_netbsd.go
+++ b/termios/pty_netbsd.go
@@ -1,0 +1,31 @@
+package termios
+
+import (
+	"bytes"
+
+	"golang.org/x/sys/unix"
+)
+
+func open_pty_master() (uintptr, error) {
+	fd, err := unix.Open("/dev/ptmx", unix.O_NOCTTY|unix.O_RDWR, 0666)
+	if err != nil {
+		return 0, err
+	}
+	return uintptr(fd), nil
+}
+
+func Ptsname(fd uintptr) (string, error) {
+	ptm, err := unix.IoctlGetPtmget(int(fd), unix.TIOCPTSNAME)
+	if err != nil {
+		return "", err
+	}
+	return string(ptm.Sn[:bytes.IndexByte(ptm.Sn[:], 0)]), nil
+}
+
+func grantpt(fd uintptr) error {
+	return unix.IoctlSetInt(int(fd), unix.TIOCGRANTPT, 0)
+}
+
+func unlockpt(fd uintptr) error {
+	return nil
+}


### PR DESCRIPTION
Instead of calling C.posix_openpt, C.ptsname, C.grantpt and C.unlockpt
reimplement them in Go according to the respective man pages:

http://netbsd.gw.com/cgi-bin/man-cgi?posix_openpt++NetBSD-current
http://netbsd.gw.com/cgi-bin/man-cgi?ptsname+3+NetBSD-current
http://netbsd.gw.com/cgi-bin/man-cgi?grantpt+3+NetBSD-current
http://netbsd.gw.com/cgi-bin/man-cgi?unlockpt+3+NetBSD-current

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>