### PR TITLE
Fix build on Solaris with recent golang.org/x/sys/unix

### DIFF
--- a/termios/ioctl_solaris.go
+++ b/termios/ioctl_solaris.go
@@ -3,5 +3,5 @@ package termios
 import "golang.org/x/sys/unix"
 
 func ioctl(fd, request, argp uintptr) error {
-	return unix.IoctlSetInt(int(fd), int(request), int(argp))
+	return unix.IoctlSetInt(int(fd), uint(request), int(argp))
 }

--- a/termios/termios_solaris.go
+++ b/termios/termios_solaris.go
@@ -31,13 +31,13 @@ const FIORDCHK = C.FIORDCHK
 // Tcgetattr gets the current serial port settings.
 func Tcgetattr(fd uintptr, argp *syscall.Termios) error {
 	termios, err := unix.IoctlGetTermios(int(fd), unix.TCGETS)
-	*argp = syscall.Termios(*termios)
+	*argp = *(tiosToSyscall(termios))
 	return err
 }
 
 // Tcsetattr sets the current serial port settings.
 func Tcsetattr(fd, action uintptr, argp *syscall.Termios) error {
-	return unix.IoctlSetTermios(int(fd), int(action), (*unix.Termios)(argp))
+	return unix.IoctlSetTermios(int(fd), uint(action), tiosToUnix(argp))
 }
 
 // Tcsendbreak transmits a continuous stream of zero-valued bits for a specific
@@ -77,26 +77,51 @@ func Tiocoutq(fd uintptr, argp *int) error {
 
 // Cfgetispeed returns the input baud rate stored in the termios structure.
 func Cfgetispeed(attr *syscall.Termios) uint32 {
-	solTermios := (*unix.Termios)(attr)
+	solTermios := tiosToUnix(attr)
 	return uint32(C.cfgetispeed((*C.termios_t)(unsafe.Pointer(solTermios))))
 }
 
 // Cfsetispeed sets the input baud rate stored in the termios structure.
 func Cfsetispeed(attr *syscall.Termios, speed uintptr) error {
-	solTermios := (*unix.Termios)(attr)
+	solTermios := tiosToUnix(attr)
 	_, err := C.cfsetispeed((*C.termios_t)(unsafe.Pointer(solTermios)), C.speed_t(speed))
 	return err
 }
 
 // Cfgetospeed returns the output baud rate stored in the termios structure.
 func Cfgetospeed(attr *syscall.Termios) uint32 {
-	solTermios := (*unix.Termios)(attr)
+	solTermios := tiosToUnix(attr)
 	return uint32(C.cfgetospeed((*C.termios_t)(unsafe.Pointer(solTermios))))
 }
 
 // Cfsetospeed sets the output baud rate stored in the termios structure.
 func Cfsetospeed(attr *syscall.Termios, speed uintptr) error {
-	solTermios := (*unix.Termios)(attr)
+	solTermios := tiosToUnix(attr)
 	_, err := C.cfsetospeed((*C.termios_t)(unsafe.Pointer(solTermios)), C.speed_t(speed))
 	return err
+}
+
+
+// tiosToUnix copies a syscall.Termios to a x/sys/unix.Termios.
+// This is needed since type conversions between the two fail due to
+// more recent x/sys/unix.Termios renaming the padding field.
+func tiosToUnix(st *syscall.Termios) *unix.Termios {
+	return &unix.Termios{
+		Iflag:  st.Iflag,
+		Oflag:  st.Oflag,
+		Cflag:  st.Cflag,
+		Lflag:  st.Lflag,
+		Cc:     st.Cc,
+	}
+}
+
+// tiosToSyscall copies a x/sys/unix.Termios to a syscall.Termios.
+func tiosToSyscall(ut *unix.Termios) *syscall.Termios {
+	return &syscall.Termios{
+		Iflag:  ut.Iflag,
+		Oflag:  ut.Oflag,
+		Cflag:  ut.Cflag,
+		Lflag:  ut.Lflag,
+		Cc:     ut.Cc,
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/pkg/term/issues/40.

Term fails to build with recent golang.org/x/sys/unix versions if `GOOS == solaris`.
This is due to two commits:

1. https://github.com/golang/sys/commit/a55a76086885b80f79961eacb876ebd8caf3868d changed `Ioctl{Get,Set}Int(int, int, int)` to `Ioctl{Get,Set}Int(int, uint, int)`. (@jperkin This obviously is a "linuxism".)
2. https://github.com/golang/sys/commit/6035cb031ffa600cb6dc48685f04236a802173ac changed the "signature" of `unix.Termios`, making type conversions to/from `syscall.Termios` fail.

The fix for 1. is trivial.

To fix 2. I  copied the struct where conversions would apply. Copying was chosen to make the code more robust. This is inline with the explicit type conversions used in the code. (While converting to `unsafe.Pointer()` would work to, possible future changes to the  x/sys/unix.Termios struct may break the code, so I took the overhead of copying.)


