### PR TITLE
Add support for obtaining window size options.

### DIFF
--- a/term.go
+++ b/term.go
@@ -77,3 +77,8 @@ func (t *Term) Buffered() (int, error) {
 	err := termios.Tiocoutq(uintptr(t.fd), &n)
 	return n, err
 }
+
+// GetWinSize returns the window size as rows, cols.
+func (t *Term) GetWinSize() (int, int, error) {
+	return termios.GetWinSize(uintptr(t.fd))
+}

--- a/term_linux.go
+++ b/term_linux.go
@@ -1,6 +1,8 @@
 package term
 
-import "syscall"
+import (
+	"syscall"
+)
 
 type attr syscall.Termios
 

--- a/term_test.go
+++ b/term_test.go
@@ -28,6 +28,7 @@ var _ interface {
 	SetSpeed(baud int) error
 	GetSpeed() (int, error)
 	Write(b []byte) (int, error)
+	GetWinSize() (int, int, error)
 } = new(Term)
 
 func TestTermSetCbreak(t *testing.T) {
@@ -85,6 +86,16 @@ func TestTermRestore(t *testing.T) {
 	tt := opendev(t)
 	defer tt.Close()
 	if err := tt.Restore(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetWinSize(t *testing.T) {
+	// NB: Pty will not have a valid window size; for that
+	// we would need /dev/tty.
+	tt := opendev(t)
+	defer tt.Close()
+	if _, _, err := tt.GetWinSize(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/termios/termios_bsd.go
+++ b/termios/termios_bsd.go
@@ -6,6 +6,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -87,4 +89,10 @@ func Tiocinq(fd uintptr, argp *int) error {
 // Tiocoutq return the number of bytes in the output buffer.
 func Tiocoutq(fd uintptr, argp *int) error {
 	return ioctl(fd, syscall.TIOCOUTQ, uintptr(unsafe.Pointer(argp)))
+}
+
+// GetWinSize returns the window dimenions as rows, cols.
+func GetWinSize(fd uintptr) (int, int, error) {
+	wsz, err := unix.IoctlGetWinsize(int(fd), syscall.TIOCGWINSZ)
+	return int(wsz.Row), int(wsz.Col), err
 }

--- a/termios/termios_linux.go
+++ b/termios/termios_linux.go
@@ -3,6 +3,8 @@ package termios
 import (
 	"syscall"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -79,3 +81,9 @@ func Cfgetispeed(attr *syscall.Termios) uint32 { return attr.Ispeed }
 
 // Cfgetospeed returns the output baud rate stored in the termios structure.
 func Cfgetospeed(attr *syscall.Termios) uint32 { return attr.Ospeed }
+
+// GetWinSize returns the window dimenions as rows, cols.
+func GetWinSize(fd uintptr) (int, int, error) {
+	wsz, err := unix.IoctlGetWinsize(int(fd), syscall.TIOCGWINSZ)
+	return int(wsz.Row), int(wsz.Col), err
+}

--- a/termios/termios_solaris.go
+++ b/termios/termios_solaris.go
@@ -7,8 +7,9 @@ import "C"
 import (
 	"syscall"
 
-	"golang.org/x/sys/unix"
 	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -101,27 +102,32 @@ func Cfsetospeed(attr *syscall.Termios, speed uintptr) error {
 	return err
 }
 
-
 // tiosToUnix copies a syscall.Termios to a x/sys/unix.Termios.
 // This is needed since type conversions between the two fail due to
 // more recent x/sys/unix.Termios renaming the padding field.
 func tiosToUnix(st *syscall.Termios) *unix.Termios {
 	return &unix.Termios{
-		Iflag:  st.Iflag,
-		Oflag:  st.Oflag,
-		Cflag:  st.Cflag,
-		Lflag:  st.Lflag,
-		Cc:     st.Cc,
+		Iflag: st.Iflag,
+		Oflag: st.Oflag,
+		Cflag: st.Cflag,
+		Lflag: st.Lflag,
+		Cc:    st.Cc,
 	}
 }
 
 // tiosToSyscall copies a x/sys/unix.Termios to a syscall.Termios.
 func tiosToSyscall(ut *unix.Termios) *syscall.Termios {
 	return &syscall.Termios{
-		Iflag:  ut.Iflag,
-		Oflag:  ut.Oflag,
-		Cflag:  ut.Cflag,
-		Lflag:  ut.Lflag,
-		Cc:     ut.Cc,
+		Iflag: ut.Iflag,
+		Oflag: ut.Oflag,
+		Cflag: ut.Cflag,
+		Lflag: ut.Lflag,
+		Cc:    ut.Cc,
 	}
+}
+
+// GetWinSize returns the window dimenions as rows, cols.
+func GetWinSize(fd uintptr) (int, int, error) {
+	wsz, err := unix.IoctlGetWinsize(int(fd), syscall.TIOCGWINSZ)
+	return int(wsz.Row), int(wsz.Col), err
 }

--- a/termios/termios_test.go
+++ b/termios/termios_test.go
@@ -153,6 +153,23 @@ func TestCfgetospeed(t *testing.T) {
 	}
 }
 
+func TestGetWinSize(t *testing.T) {
+	// We need to open /dev/tty rather than a pty, as ptys
+	// don't give back valid window sizes.
+	f, err := os.Open(*dev)
+	if err != nil {
+		t.SkipNow()
+	}
+	defer f.Close()
+
+	rows, cols, err := GetWinSize(f.Fd())
+	if err != nil {
+		t.Fatal(err)
+	} else if rows == 0 || cols == 0 {
+		t.Fatalf("GetWinSize: invalid dimensions, rows %d cols %d", rows, cols)
+	}
+}
+
 func opendev(t *testing.T) *os.File {
 	_, pts, err := Pty()
 	if err != nil {


### PR DESCRIPTION
This builds upon PR #45, but it could also be rebased ahead if desired.  This adds a nice way for us to get the Window size, which is very useful for applications like tcell.

There is some gofmt noise, as my editor automatically runs go fmt to clean things up.  If that is bothersome, let me know and I'll strip that out.