### PR TITLE
Fix build on illumos

### DIFF
--- a/term_solaris.go
+++ b/term_solaris.go
@@ -18,55 +18,51 @@ func (a *attr) getSpeed() (int, error) {
 	// We generally only care about ospeed, since that's what would
 	// be used for padding characters, for example.
 
-	rate := termios.Cfgetospeed((*syscall.Termios)(a))
+	rate := termios.Cfgetospeed((*unix.Termios)(a))
 
 	switch rate {
-	case syscall.B50:
+	case unix.B50:
 		return 50, nil
-	case syscall.B75:
+	case unix.B75:
 		return 75, nil
-	case syscall.B110:
+	case unix.B110:
 		return 110, nil
-	case syscall.B134:
+	case unix.B134:
 		return 134, nil
-	case syscall.B150:
+	case unix.B150:
 		return 150, nil
-	case syscall.B200:
+	case unix.B200:
 		return 200, nil
-	case syscall.B300:
+	case unix.B300:
 		return 300, nil
-	case syscall.B600:
+	case unix.B600:
 		return 600, nil
-	case syscall.B1200:
+	case unix.B1200:
 		return 1200, nil
-	case syscall.B1800:
+	case unix.B1800:
 		return 1800, nil
-	case syscall.B2400:
+	case unix.B2400:
 		return 2400, nil
-	case syscall.B4800:
+	case unix.B4800:
 		return 4800, nil
-	case syscall.B9600:
+	case unix.B9600:
 		return 9600, nil
-	case syscall.B19200:
+	case unix.B19200:
 		return 19200, nil
-	case syscall.B38400:
+	case unix.B38400:
 		return 38400, nil
-	case syscall.B57600:
+	case unix.B57600:
 		return 57600, nil
-	case syscall.B115200:
+	case unix.B115200:
 		return 115200, nil
-	case syscall.B230400:
+	case unix.B230400:
 		return 230400, nil
-	case syscall.B460800:
+	case unix.B460800:
 		return 460800, nil
-	case syscall.B500000:
-		return 500000, nil
-	case syscall.B576000:
-		return 576000, nil
-	case syscall.B921600:
+	case unix.B921600:
 		return 921600, nil
 	default:
-		return 0, syscall.EINVAL
+		return 0, unix.EINVAL
 	}
 }
 
@@ -139,7 +135,7 @@ func Open(name string, options ...func(*Term) error) (*Term, error) {
 
 	modules := [2]string{"ptem", "ldterm"}
 	for _, mod := range modules {
-		err := unix.IoctlSetInt(fd, C.I_PUSH, int(uintptr(unsafe.Pointer(unix.StringBytePtr(mod)))))
+		err := unix.IoctlSetInt(fd, C.I_PUSH, int(uintptr(unsafe.Pointer(syscall.StringBytePtr(mod)))))
 		if err != nil {
 			return nil, err
 		}

--- a/termios/termios_solaris.go
+++ b/termios/termios_solaris.go
@@ -63,14 +63,13 @@ func Tcflush(fd, selector uintptr) error {
 }
 
 // Tiocinq returns the number of bytes in the input buffer.
-func Tiocinq(fd uintptr, argp *int) (err error) {
-	*argp, err = unix.IoctlGetInt(int(fd), FIORDCHK)
-	return err
+func Tiocinq(fd uintptr) (int, error) {
+	return unix.IoctlGetInt(int(fd), FIORDCHK)
 }
 
 // Tiocoutq return the number of bytes in the output buffer.
-func Tiocoutq(fd uintptr, argp *int) error {
-	return ioctl(fd, unix.TIOCOUTQ, uintptr(unsafe.Pointer(argp)))
+func Tiocoutq(fd uintptr) (int, error) {
+	return unix.IoctlGetInt(int(fd), unix.TIOCOUTQ)
 }
 
 // Cfgetispeed returns the input baud rate stored in the termios structure.


### PR DESCRIPTION
The syscall -> unix rename broke a few things on illumos/solaris:
<pre>
% go install -v ./...
github.com/pkg/term
# github.com/pkg/term
./term.go:71:2: not enough arguments to return
	have (error)
	want (int, error)
./term.go:71:24: not enough arguments in call to termios.Tiocinq
	have (uintptr)
	want (uintptr, *int)
./term.go:76:2: not enough arguments to return
	have (error)
	want (int, error)
./term.go:76:25: not enough arguments in call to termios.Tiocoutq
	have (uintptr)
	want (uintptr, *int)
./term_solaris.go:21:48: cannot convert a (type *attr) to type *syscall.Termios
./term_solaris.go:62:7: undefined: syscall.B500000
./term_solaris.go:64:7: undefined: syscall.B576000
./term_solaris.go:142:68: undefined: unix.StringBytePtr
</pre>