### PR TITLE
Fix ptsname() for big-endian architectures

### DIFF
--- a/termios/pty_linux.go
+++ b/termios/pty_linux.go
@@ -12,7 +12,7 @@ func open_pty_master() (uintptr, error) {
 }
 
 func Ptsname(fd uintptr) (string, error) {
-	var n uintptr
+	var n uint32
 	err := ioctl(fd, unix.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
 	if err != nil {
 		return "", err


### PR DESCRIPTION
This pull request fixes the same issue on big-endian architectures as [the inspiring pull request](https://github.com/containerd/console/pull/20 ) to `github.com/containerd/console`.

```
[linux1@lnx1a term]$ uname -a
Linux lnx1a.marist.edu 4.18.0-193.13.2.el8_2.s390x #1 SMP Mon Jul 13 23:23:50 UTC 2020 s390x s390x s390x GNU/Linux
[linux1@lnx1a term]$ git log -1
commit d02e49dd31404f3c3cf4b5469b28942194e0ca23 (HEAD -> master, tag: v1.1.0)
Merge: 8ae29be d86faa3
Author: Dave Cheney <dave@cheney.net>
Date:   Mon Sep 14 12:15:29 2020 +1000

    Merge branch 'gdamore-getspeed'
[linux1@lnx1a term]$ git status
On branch master
Your branch is behind 'origin/master' by 1 commit, and can be fast-forwarded.
  (use "git pull" to update your local branch)

nothing to commit, working tree clean
[linux1@lnx1a term]$ go test ./...
--- FAIL: TestTermSetCbreak (0.00s)
    term_test.go:97: unable to open "/dev/pts/8589934592": no such file or directory
--- FAIL: TestTermSetRaw (0.00s)
    term_test.go:97: unable to open "/dev/pts/17179869184": no such file or directory
--- FAIL: TestTermSetSpeed (0.00s)
    term_test.go:97: unable to open "/dev/pts/21474836480": no such file or directory
--- FAIL: TestTermSetReadTimeout (0.00s)
    term_test.go:97: unable to open "/dev/pts/25769803776": no such file or directory
--- FAIL: TestTermSetFlowControl (0.00s)
    term_test.go:97: unable to open "/dev/pts/30064771072": no such file or directory
--- FAIL: TestTermRestore (0.00s)
    term_test.go:97: unable to open "/dev/pts/34359738368": no such file or directory
FAIL
FAIL	github.com/pkg/term	0.004s
--- FAIL: TestTcflush (0.00s)
    termios_test.go:159: unable to open "/dev/pts/8589934592": no such file or directory
--- FAIL: TestTcgetattr (0.00s)
    termios_test.go:159: unable to open "/dev/pts/17179869184": no such file or directory
--- FAIL: TestTcsetattr (0.00s)
    termios_test.go:159: unable to open "/dev/pts/21474836480": no such file or directory
--- FAIL: TestTcsendbreak (0.00s)
    termios_test.go:159: unable to open "/dev/pts/25769803776": no such file or directory
--- FAIL: TestTcdrain (0.00s)
    termios_test.go:159: unable to open "/dev/pts/30064771072": no such file or directory
--- FAIL: TestTiocmget (0.00s)
    termios_test.go:159: unable to open "/dev/pts/34359738368": no such file or directory
--- FAIL: TestTiocmset (0.00s)
    termios_test.go:159: unable to open "/dev/pts/38654705664": no such file or directory
--- FAIL: TestTiocmbis (0.00s)
    termios_test.go:159: unable to open "/dev/pts/42949672960": no such file or directory
--- FAIL: TestTiocmbic (0.00s)
    termios_test.go:159: unable to open "/dev/pts/47244640256": no such file or directory
--- FAIL: TestTiocinq (0.00s)
    termios_test.go:159: unable to open "/dev/pts/51539607552": no such file or directory
--- FAIL: TestTiocoutq (0.00s)
    termios_test.go:159: unable to open "/dev/pts/55834574848": no such file or directory
--- FAIL: TestCfgetispeed (0.00s)
    termios_test.go:159: unable to open "/dev/pts/60129542144": no such file or directory
--- FAIL: TestCfgetospeed (0.00s)
    termios_test.go:159: unable to open "/dev/pts/64424509440": no such file or directory
FAIL
FAIL	github.com/pkg/term/termios	0.001s
FAIL
[linux1@lnx1a term]$ git pull -r
Updating d02e49d..86dad31
Fast-forward
 termios/pty_linux.go | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
[linux1@lnx1a term]$ git log -1
commit 86dad31139dac86af1c47c72d1a248741ed632c5 (HEAD -> master, origin/master)
Author: Tim Otto <tim@timotto.io>
Date:   Sat Dec 5 09:40:54 2020 +0100

    Fix ptsname() for big-endian architectures
[linux1@lnx1a term]$ go test ./...
ok  	github.com/pkg/term	(cached)
ok  	github.com/pkg/term/termios	(cached)
[linux1@lnx1a term]$ 
```