### PR TITLE
Return EINVAL when calling SetSpeed

### DIFF
--- a/term_posix.go
+++ b/term_posix.go
@@ -90,7 +90,12 @@ func (t *Term) setSpeed(baud int) error {
 	if err != nil {
 		return err
 	}
-	(*attr)(a).setSpeed(baud)
+
+	err = (*attr)(a).setSpeed(baud)
+	if err != nil {
+		return err
+	}
+
 	return termios.Tcsetattr(uintptr(t.fd), termios.TCSANOW, a)
 }
 

--- a/term_test.go
+++ b/term_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/pkg/term/termios"
+	"golang.org/x/sys/unix"
 )
 
 // assert that Term implements the same method set across
@@ -63,6 +64,14 @@ func TestTermSetSpeed(t *testing.T) {
 		t.Fatal(err)
 	} else if spd != 57600 {
 		t.Errorf("speed mismatch %d != 57600", spd)
+	}
+}
+
+func TestTermSetInvalidSpeed(t *testing.T) {
+	tt := opendev(t)
+	defer tt.Close()
+	if err := tt.SetSpeed(12345); err != unix.EINVAL {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
Don't squash invalid setSpeed result.