### PR TITLE
Avoid leaking ptm fd in case of an error

### DIFF
--- a/termios/pty.go
+++ b/termios/pty.go
@@ -27,21 +27,25 @@ func Pty() (*os.File, *os.File, error) {
 
 	sname, err := Ptsname(ptm)
 	if err != nil {
+		unix.Close(int(ptm))
 		return nil, nil, err
 	}
 
 	err = grantpt(ptm)
 	if err != nil {
+		unix.Close(int(ptm))
 		return nil, nil, err
 	}
 
 	err = unlockpt(ptm)
 	if err != nil {
+		unix.Close(int(ptm))
 		return nil, nil, err
 	}
 
 	pts, err := open_device(sname)
 	if err != nil {
+		unix.Close(int(ptm))
 		return nil, nil, err
 	}
 	return os.NewFile(uintptr(ptm), "ptm"), os.NewFile(uintptr(pts), sname), nil


### PR DESCRIPTION
In func Pty, the ptm fd (pty master) is only wrapped into an *os.File at
the end of the function. Before that, ptm needs to be closed explicitly
in case of an error.