### PR TITLE
Fix error running tests on Linux kernel 5.13 or newer

### DIFF
--- a/termios/termios_test.go
+++ b/termios/termios_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package termios
@@ -152,7 +153,7 @@ func checktty(t *testing.T, err error) {
 	t.Helper()
 	// some ioctls fail against char devices if they do not
 	// support a particular feature
-	if (runtime.GOOS == "darwin" && err == unix.ENOTTY) || (runtime.GOOS == "linux" && err == unix.EINVAL) {
+	if ((runtime.GOOS == "darwin" || runtime.GOOS == "linux") && err == unix.ENOTTY) || (runtime.GOOS == "linux" && err == unix.EINVAL) {
 		t.Skip(err)
 	}
 }


### PR DESCRIPTION
As of torvalds/linux@1b8b20868a6d64cfe8174a21b25b74367bdf0560, unsupported ioctls now return ENOTTY instead of EINVAL. This change was also backported to the 5.10 stable branch, so it's a problem on the current release of many Linux distros now.