### PR TITLE
Skip pty_test on Windows

### DIFF
--- a/termios/pty_test.go
+++ b/termios/pty_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package termios
 
 import (


### PR DESCRIPTION
It does not build on Windows due to undefined open_pty_master and Ptsname.